### PR TITLE
Fluent way to define returns/throws

### DIFF
--- a/src/main/scala/com/wixpress/common/specs2/JMock.scala
+++ b/src/main/scala/com/wixpress/common/specs2/JMock.scala
@@ -73,13 +73,16 @@ trait JMock extends MustMatchers with AroundExample with ArgumentsShortcuts with
   def waitUntil(p : StatePredicate, timeoutMs : Long) = synchroniser.waitUntil(p,timeoutMs)
 
   implicit class Stubbed [T](c: T) {
+
     def will(action: Action, consecutive: Action*): Unit = {
       if (consecutive.isEmpty)
         expectations.will(action)
       else
         expectations.will(Expectations.onConsecutiveCalls((action +:consecutive):_*))
     }
+
     def willReturn[K](t: K): Unit = will(returnValue(t))
+    
     def willThrow[K <: Throwable](t: K): Unit = will(throwException(t))
   }
 }

--- a/src/test/scala/com/wixpress/common/specs2/JMockTest.scala
+++ b/src/test/scala/com/wixpress/common/specs2/JMockTest.scala
@@ -145,8 +145,8 @@ class JMockTest extends Specification with JMock {
     }
   }
 
-  "JMock.Stubbed implicit class" should {
-    "support willReturn" in {
+  "JMock.Stubbed" >> {
+    "'willReturn' should work as will(returnValue)" in {
       val mockDummy = mock[Dummy]
       checking {
         oneOf(mockDummy).func1 willReturn "some"
@@ -155,7 +155,7 @@ class JMockTest extends Specification with JMock {
       mockDummy.func1 mustEqual "some"
     }
 
-    "support willThrow" in {
+    "'willThrow' should work as will(throwException)" in {
       val mockDummy = mock[Dummy]
       checking {
         oneOf(mockDummy).func1 willThrow new RuntimeException
@@ -164,7 +164,7 @@ class JMockTest extends Specification with JMock {
       mockDummy.func1 must throwA[RuntimeException]
     }
 
-    "support will with single arg as JMock.will" in {
+    "'will' with a single arg should act as JMock.will" in {
       val mockDummy = mock[Dummy]
       checking {
         allowing(mockDummy).func1 will returnValue("some")
@@ -174,13 +174,12 @@ class JMockTest extends Specification with JMock {
       mockDummy.func1 mustEqual "some"
     }
 
-    "support will with varargs as JMock.onConsecutiveCalls" in {
+    "'will' with multiple args should act as JMock.will with onConsecutiveCalls" in {
       val mockDummy = mock[Dummy]
       checking {
-        allowing(mockDummy).func1 will(
+        allowing(mockDummy).func1 will (
           returnValue("first"),
-          returnValue("second")
-          )
+          returnValue("second"))
       }
 
       mockDummy.func1 mustEqual "first"


### PR DESCRIPTION
Ok, so I find current syntax somewhat annoying to define returns/throws.

```
///takes 2 lines
oneOf(mock).func1
will(returnValue("ret"))

//can be a single line
oneOf(mock).func1; will(returnValue("ret"))
// but autoformatting messes it up
```

It's quite easy to have a more fluent syntax while keeping it in sync with original JMock syntax:

```
//using original constructs
oneOf(mock).func1 will returnValue("ret")

//shortcut for will(returnValue("ret"))
oneOf(mock).func1 willReturn "ret"

//shortcut for will(ThrowException(new RuntimeException))
oneOf(mock).func1 willThrow new RuntimeException

//shortcut for will(onConsecutiveCalls(...))
allowing(mock).func1 will(
  returnValue("first")
  returnValue("second")
)
```

I find these useful myself and have them in action-triggers module, but I would love to have them in base library to reuse across the projects.

willReturn/willThrow are a nice to have, but will(...) on the same line imho is a must:)

What do you think?
