### PR TITLE
Added DeterministicExecutionContext to allow easier work with JMock and Futures

### DIFF
--- a/src/main/scala/com/wixpress/common/specs2/DeterministicExecutionContext.scala
+++ b/src/main/scala/com/wixpress/common/specs2/DeterministicExecutionContext.scala
@@ -1,0 +1,34 @@
+package com.wixpress.common.specs2
+
+import org.jmock.lib.concurrent.DeterministicExecutor
+import org.specs2.execute.{AsResult, Result}
+import org.specs2.matcher.ConcurrentExecutionContext
+import org.specs2.specification.AroundExample
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * Sets up an implicit [[scala.concurrent.ExecutionContext]] backed with [[org.jmock.lib.concurrent.DeterministicExecutor]].
+ *
+ * All submitted tasks are executed in background thread before evaluating test result.
+ *
+ * Needed to override [[org.specs2.matcher.ConcurrentExecutionContext]] here to avoid conflicting implicit [[scala.concurrent.ExecutionContext]].
+ *
+ * NOTE: Mixin this trait after [[com.wixpress.common.specs2.JMock]] trait.
+ */
+trait DeterministicExecutionContext extends ConcurrentExecutionContext with AroundExample {
+
+  private val executor = new DeterministicExecutor
+
+  override implicit def concurrentExecutionContext: ExecutionContext = new ExecutionContext {
+    override def execute(runnable: Runnable): Unit = executor.execute(runnable)
+
+    override def reportFailure(cause: Throwable): Unit = throw cause
+  }
+
+  abstract override protected def around[T: AsResult](t: => T): Result = {
+    val example = t
+    executor.runUntilIdle()
+    super.around(example)
+  }
+}

--- a/src/test/scala/com/wixpress/common/specs2/DeterministicExecutionContextTest.scala
+++ b/src/test/scala/com/wixpress/common/specs2/DeterministicExecutionContextTest.scala
@@ -1,0 +1,46 @@
+package com.wixpress.common.specs2
+
+import java.lang.System.currentTimeMillis
+import java.util.concurrent.TimeUnit.SECONDS
+
+import org.specs2.mutable.Specification
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeterministicExecutionContextTest extends Specification with JMock with DeterministicExecutionContext {
+
+  "DeterministicExecutionContext trait" should {
+
+    "execute async expectations in background thread before evaluating test result" in {
+
+      val service = mock[Service]
+      val component = new Component(service)
+      val delay = Duration(1, SECONDS)
+
+      checking {
+        oneOf(service).doSideEffect()
+      }
+
+      val startOfCallInTestThread = currentTimeMillis
+
+      component.doSideEffectAfter(delay)
+
+      currentTimeMillis - startOfCallInTestThread must be_<=(delay.toMillis)
+    }
+
+  }
+
+}
+
+class Component(service: Service)(implicit ctx: ExecutionContext) {
+  def doSideEffectAfter(delay: Duration): Unit = Future {
+    Thread.sleep(delay.toMillis)
+
+    service.doSideEffect()
+  }
+}
+
+trait Service {
+  def doSideEffect(): Unit
+}


### PR DESCRIPTION
This is an idea how integrate JMock's DeterministicExecutor with specs2 and Futures.

resolves #5 
