### PR TITLE
Update jmock to 2.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,10 +13,10 @@ scalaVersion := "2.12.6"
 libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "4.3.1",
   "org.specs2" %% "specs2-mock" % "4.3.1",
-  "org.jmock" % "jmock-junit4" % "2.8.4",
-  "org.jmock" % "jmock-legacy" % "2.8.4",
-  "org.hamcrest" % "hamcrest-core" % "1.3",
-  "org.hamcrest" % "hamcrest-library" % "1.3"
+  "org.jmock" % "jmock" % "2.12.0",
+  "org.jmock" % "jmock-junit4" % "2.12.0",
+  "org.jmock" % "jmock-imposters" % "2.12.0",
+  "org.hamcrest" % "hamcrest" % "2.1"
 )
 
 scalacOptions in Test ++= Seq("-Yrangepos")

--- a/src/main/scala/com/wixpress/common/specs2/DelegatingImposteriser.scala
+++ b/src/main/scala/com/wixpress/common/specs2/DelegatingImposteriser.scala
@@ -1,15 +1,15 @@
 package com.wixpress.common.specs2
 
-import org.jmock.api.{Invokable, Imposteriser}
+import org.jmock.api.{Imposteriser, Invokable}
+import org.jmock.imposters.ByteBuddyClassImposteriser
 import org.jmock.lib.JavaReflectionImposteriser
-import org.jmock.lib.legacy.ClassImposteriser
 
 import scala.util.Try
 
 class DelegatingImposteriser(jmock: JMockDsl) extends Imposteriser {
 
   val reflectionImposteriser = JavaReflectionImposteriser.INSTANCE
-  val classImposteriser = ClassImposteriser.INSTANCE
+  val classImposteriser = ByteBuddyClassImposteriser.INSTANCE
 
   override def canImposterise(aClass: Class[_]): Boolean =
     if(jmock.usingJavaReflectionImposteriser) reflectionImposteriser.canImposterise(aClass) else classImposteriser.canImposterise(aClass)


### PR DESCRIPTION
We need this upgrade because legacy cglib ClassImposteriser doesn't work in jdk11.
Deprecated `ClassImposteriser` is replaced with new `ByteBuddyClassImposteriser`