### PR TITLE
Default args backward compatibility: in expectations by default, capture null/0/false etc.

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,24 +1,5 @@
 # Publishing to Maven Central
 
-This project publishing is not automated. Everything is executed manually from a developer machine.
-
-## Step 1. Prerequisites
-
-1. You need a OSSRH account with rights to release `com.wix` artifacts. Credentials are excpected to be available under environment variables `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`.
-2. Additionally, you need a valid PGP key for your account. This project uses sbt-pgp plugin, usage can be found here: https://github.com/sbt/sbt-pgp/wiki/Using-GPG .
-
-## Step 2. Publishing
-
-Since process is not automated, you must manually change versions before and after publishing artifacts. Please commit the changes.
- 
-Publishing itself is done by executing following command:
-
-```sh
-sbt +publishSigned
-```
-
-## Step 3. Releasing
-
-After publishing artifacts successfully, they will be visible (if you have rights) in https://oss.sonatype.org/#stagingRepositories . Make sure content looks OK, then close and release it. Usually, artifacts become available in a couple of hours. If not, wait at least 24 hours before panicking.
-
-Refer to https://central.sonatype.org/pages/ossrh-guide.html for more detailed information.
+Publishing to Maven Central is done automatically on GitHub release (by a GitHub action).\
+When releasing a new version, the tag must be prefixed a lowercase `v`.\
+For example the tag `v1.6.0`, will be published to Maven Central as version `1.6.0`

--- a/src/main/scala/com/wixpress/common/specs2/impostisers/ScalaAwareImposteriser.scala
+++ b/src/main/scala/com/wixpress/common/specs2/impostisers/ScalaAwareImposteriser.scala
@@ -1,23 +1,60 @@
 package com.wixpress.common.specs2.impostisers
 
 import com.wixpress.common.specs2.JMockDsl
+import com.wixpress.common.specs2.impostisers.ScalaAwareImposteriser.MockInCapturingState
 import org.jmock.api.{Imposteriser, Invocation, Invokable}
+import org.jmock.internal.{CaptureControl, ExpectationCapture, InvocationToExpectationTranslator, ObjectMethodExpectationBouncer, ReturnDefaultValueAction}
 
 import java.lang.reflect.Method
 
 class ScalaAwareImposteriser(delegate: Imposteriser, jmock: JMockDsl) extends Imposteriser {
+  private val defaultAction = new ReturnDefaultValueAction(delegate)
+
   override def canImposterise(`type`: Class[_]): Boolean = delegate.canImposterise(`type`)
 
   override def imposterise[T](mockObject: Invokable, mockedType: Class[T], ancilliaryTypes: Class[_]*): T = {
+    imposteriseInternal(inCaptureMode = false)(mockObject, mockedType, ancilliaryTypes:_*)
+  }
+
+  private def imposteriseInternal[T](inCaptureMode: Boolean, compatMode: Boolean = false)(mockObject: Invokable, mockedType: Class[T], ancilliaryTypes: Class[_]*) = {
     val interceptor: Invokable = new Invokable {
       override def invoke(invocation: Invocation): AnyRef = {
-        val inv: Invocation = preProcessParams(invocation)
-        if(ScalaAwareImposteriser.isDefaultArgMethod(inv.getInvokedMethod)) {
-         tryInvokeDefaultArgMethod(inv, orElse = mockObject.invoke(inv))
-        } else mockObject.invoke(inv)
-      }
+        captureExpectationToInvocation(mockedType, jmock.isDefaultArgsCompatibilityEnabled)(invocation) getOrElse {
+          val inv: Invocation = preProcessParams(invocation)
+          if (ScalaAwareImposteriser.isDefaultArgMethod(inv.getInvokedMethod)) {
+            // before default args were supported this was the behavior during expectation capture
+            if (compatMode && inCaptureMode) defaultAction.invoke(invocation)
+            else tryInvokeDefaultArgMethod(inv, orElse = mockObject.invoke(inv))
+          } else mockObject.invoke(inv)
+        }
+      }.asInstanceOf[AnyRef]
     }
     delegate.imposterise(interceptor, mockedType, ancilliaryTypes:_*)
+  }
+
+  /**
+   * if what is being invoked is [[CaptureControl.captureExpectationTo]], tag the returned mock
+   */
+  private def captureExpectationToInvocation[T](mockedType: Class[T], compatMode: Boolean)(invocation: Invocation): Option[T] = {
+    val CaptureControlClass = classOf[CaptureControl]
+    (invocation.getInvokedMethod.getName,  invocation.getInvokedMethod.getDeclaringClass, invocation.getParametersAsArray.headOption) match {
+      case ("captureExpectationTo", CaptureControlClass, Some(capture: ExpectationCapture)) =>
+        Some(makeCapturingMock(capture, mockedType, compatMode))
+      case _ => None
+    }
+  }
+
+  /**
+   * same as [[org.jmock.Mockery.MockObject.captureExpectationTo]] but adds a marker trait to the generated mock + calls imposteriseInternal(true)(...)
+   */
+  private def makeCapturingMock[T](capture: ExpectationCapture, mockedType: Class[_], compatMode: Boolean): T = {
+    imposteriseInternal[T](inCaptureMode = true, compatMode)(
+      new ObjectMethodExpectationBouncer(
+        new InvocationToExpectationTranslator(
+          capture,
+          defaultAction)),
+      mockedType.asInstanceOf[Class[T]],
+      classOf[MockInCapturingState])
   }
 
   private def preProcessParams[T](inv: Invocation) = {
@@ -52,4 +89,6 @@ object ScalaAwareImposteriser {
   private val defaultArgMethodPattern = ".*\\$default\\$\\d+".r.pattern
   def isDefaultArgMethod(method: Method) =
     method.getParameterCount == 0 && defaultArgMethodPattern.matcher(method.getName).matches()
+
+  trait MockInCapturingState
 }


### PR DESCRIPTION
#pr