### PR TITLE
Backward compatibility: mocks should not blow up when passed to jackson serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This is a specs2 adapter + DSL for using the popular mocking framework JMock
 <dependency>
     <groupId>com.wix</groupId>
     <artifactId>specs2-jmock_${scala.version}</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
     <scope>test</scope>
 </dependency>
 ```
 ### SBT
 ```sbt
-libraryDependencies += "com.wix" %% "specs2-jmock" % "1.6.1"
+libraryDependencies += "com.wix" %% "specs2-jmock" % "1.6.2"
 ```
 
 * for latest version check [releases](https://github.com/wix/specs2-jmock/releases)

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,10 @@ libraryDependencies ++= Seq(
   "org.jmock" % "jmock" % "2.12.0",
   "org.jmock" % "jmock-junit4" % "2.12.0",
   "org.jmock" % "jmock-imposters" % "2.12.0",
-  "org.hamcrest" % "hamcrest" % "2.1"
+  "org.hamcrest" % "hamcrest" % "2.1",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.12.3",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.3",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.12.3" % Test,
 )
 crossScalaVersions := Seq("2.12.10", "2.11.12")
 scalaVersion := "2.12.10"

--- a/src/test/scala/com/wixpress/common/specs2/JMockTest.scala
+++ b/src/test/scala/com/wixpress/common/specs2/JMockTest.scala
@@ -8,6 +8,7 @@ import org.specs2.specification.Scope
 
 import scala.language.implicitConversions
 import JMockTestSupport._
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.jmock.api.ExpectationError
 
 class JMockTest extends Specification with JMock {
@@ -483,7 +484,19 @@ class JMockTest extends Specification with JMock {
       mockDummy.funcWithFourParameters("hello", 1, 'k', 3.0) must be_===("hello1k3.0")
     }
   }
+  "Jackson serialization of doesn't fail" in {
+    useClassImposterizer()
+    val mapper = new ObjectMapper()
+    val builder = mock[Builder]
+    checking {
+      allowing(builder).build("foo")
+    }
+
+    val data = builder.build("foo")
+    mapper.writeValueAsString(data) === "{}"
+  }
 }
+
 
 trait Dummy {
   def func1: String
@@ -524,3 +537,9 @@ class DummyRepeater(dummy: Dummy) {
 }
 
 class HigherKind[T](kind: T)
+
+class Builder {
+  def build(foo: String): Data = Data("bar")
+}
+
+case class Data(field: String)


### PR DESCRIPTION
#pr